### PR TITLE
Add field map

### DIFF
--- a/adapter/logrus/logger.go
+++ b/adapter/logrus/logger.go
@@ -190,8 +190,19 @@ func (l *logger) GetOutput() io.Writer {
 
 func getFields(fields ...interface{}) logrus.Fields {
 	f := make(logrus.Fields)
+	offset := 0
 	for i, val := range fields {
-		if i%2 != 0 {
+		// there can be a fields map anywhere within the parameters
+		if fieldsMap, ok := val.(iface.Fields); ok {
+			for k, v := range fieldsMap {
+				f[k] = v
+			}
+			offset++
+			continue
+		}
+
+		// virtually skip any field maps found when figuring if this is a key or a value
+		if (i-offset)%2 != 0 {
 			f[fmt.Sprintf("%s", fields[i-1])] = val
 		}
 	}

--- a/logger.go
+++ b/logger.go
@@ -1,20 +1,20 @@
 package logger
 
 import (
-	"io"
-    "strings"
 	"fmt"
+	"io"
+	"strings"
 )
 
 type Level string
 
 const (
-    DisabledLevel Level = ""
-	ErrorLevel Level = "error"
-	WarnLevel  Level = "warn"
-	InfoLevel  Level = "info"
-	DebugLevel Level = "debug"
-	TraceLevel Level = "trace"
+	DisabledLevel Level = ""
+	ErrorLevel    Level = "error"
+	WarnLevel     Level = "warn"
+	InfoLevel     Level = "info"
+	DebugLevel    Level = "debug"
+	TraceLevel    Level = "trace"
 )
 
 type Logger interface {
@@ -35,6 +35,8 @@ type NestedLogger interface {
 type FieldLogger interface {
 	WithFields(fields ...interface{}) MessageLogger
 }
+
+type Fields map[string]interface{}
 
 type MessageLogger interface {
 	ErrorMessageLogger
@@ -94,27 +96,27 @@ func LevelFromString(l string) (Level, error) {
 }
 
 func LevelFromVerbosity(v int, levels ...Level) Level {
-    if len(levels) == 0 {
-        return DisabledLevel
-    }
-    if v > len(levels) {
-        return levels[v-1]
-    }
-    if v <= 0 {
-        return levels[0]
-    }
-    return levels[v]
+	if len(levels) == 0 {
+		return DisabledLevel
+	}
+	if v > len(levels) {
+		return levels[v-1]
+	}
+	if v <= 0 {
+		return levels[0]
+	}
+	return levels[v]
 }
 
 func IsLevel(l Level, levels ...Level) bool {
-    for _, level := range levels {
-        if l == level {
-            return true
-        }
-    }
-    return false
+	for _, level := range levels {
+		if l == level {
+			return true
+		}
+	}
+	return false
 }
 
 func IsVerbose(level Level) bool {
-    return IsLevel(level, InfoLevel, DebugLevel)
+	return IsLevel(level, InfoLevel, DebugLevel)
 }


### PR DESCRIPTION
Allows for a caller to specify fields as a map:
```golang
fields := logger.Fields{
  "key": "value"
  "number": 3
}

log.WithFields(fields).Info("message")
```

Additionally gofmts source