### PR TITLE
Add redaction logger and CI pipeline

### DIFF
--- a/.bouncer.yaml
+++ b/.bouncer.yaml
@@ -1,0 +1,61 @@
+permit:
+  - BSD.*
+  - CC0.*
+  - MIT.*
+  - Apache.*
+  - MPL.*
+  - ISC
+  - WTFPL
+
+ignore-packages:
+  # packageurl-go is released under the MIT license located in the root of the repo at /mit.LICENSE
+  - github.com/anchore/packageurl-go
+
+  # both of these dependencies are specified as Apache-2.0 in their respective GitHub READMEs
+  - github.com/alibabacloud-go/cr-20160607/client
+  - github.com/alibabacloud-go/tea-xml/service
+
+  # crypto/internal/boring is released under the openSSL license as a part of the Golang Standard Libary
+  - crypto/internal/boring
+
+  # from: https://github.com/spdx/tools-golang/blob/main/LICENSE.code
+  # The tools-golang source code is provided and may be used, at your option,
+  # under either:
+  # * Apache License, version 2.0 (Apache-2.0), OR
+  # * GNU General Public License, version 2.0 or later (GPL-2.0-or-later).
+  # (we choose Apache-2.0)
+  - github.com/spdx/tools-golang
+
+  # from: https://github.com/xi2/xz/blob/master/LICENSE
+  # All these files have been put into the public domain.
+  # You can do whatever you want with these files.
+  - github.com/xi2/xz
+
+  # from: https://gitlab.com/cznic/sqlite/-/blob/v1.15.4/LICENSE
+  # This is a BSD-3-Clause license
+  - modernc.org/libc
+  - modernc.org/libc/errno
+  - modernc.org/libc/fcntl
+  - modernc.org/libc/fts
+  - modernc.org/libc/grp
+  - modernc.org/libc/langinfo
+  - modernc.org/libc/limits
+  - modernc.org/libc/netdb
+  - modernc.org/libc/netinet/in
+  - modernc.org/libc/poll
+  - modernc.org/libc/pthread
+  - modernc.org/libc/pwd
+  - modernc.org/libc/signal
+  - modernc.org/libc/stdio
+  - modernc.org/libc/stdlib
+  - modernc.org/libc/sys/socket
+  - modernc.org/libc/sys/stat
+  - modernc.org/libc/sys/types
+  - modernc.org/libc/termios
+  - modernc.org/libc/time
+  - modernc.org/libc/unistd
+  - modernc.org/libc/utime
+  - modernc.org/libc/uuid/uuid
+  - modernc.org/libc/wctype
+  - modernc.org/mathutil
+  - modernc.org/memory

--- a/.github/scripts/go-mod-tidy-check.sh
+++ b/.github/scripts/go-mod-tidy-check.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -eu
+
+ORIGINAL_STATE_DIR=$(mktemp -d "TEMP-original-state-XXXXXXXXX")
+TIDY_STATE_DIR=$(mktemp -d "TEMP-tidy-state-XXXXXXXXX")
+
+trap "cp ${ORIGINAL_STATE_DIR}/* ./ && rm -fR ${ORIGINAL_STATE_DIR} ${TIDY_STATE_DIR}" EXIT
+
+# capturing original state of files...
+cp go.mod go.sum "${ORIGINAL_STATE_DIR}"
+
+# capturing state of go.mod and go.sum after running go mod tidy...
+go mod tidy
+cp go.mod go.sum "${TIDY_STATE_DIR}"
+
+set +e
+
+# detect difference between the git HEAD state and the go mod tidy state
+DIFF_MOD=$(diff -u "${ORIGINAL_STATE_DIR}/go.mod" "${TIDY_STATE_DIR}/go.mod")
+DIFF_SUM=$(diff -u "${ORIGINAL_STATE_DIR}/go.sum" "${TIDY_STATE_DIR}/go.sum")
+
+if [[ -n "${DIFF_MOD}" || -n "${DIFF_SUM}" ]]; then
+    echo "go.mod diff:"
+    echo "${DIFF_MOD}"
+    echo "go.sum diff:"
+    echo "${DIFF_SUM}"
+    echo ""
+    printf "FAILED! go.mod and/or go.sum are NOT tidy; please run 'go mod tidy'.\n\n"
+    exit 1
+fi

--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -1,0 +1,79 @@
+name: "Validations"
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+
+env:
+  GO_VERSION: "1.18.x"
+  GO_CACHE_KEY: efa04b89c1b1
+
+jobs:
+
+  Static-Analysis:
+    name: "Static analysis"
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - uses: actions/checkout@v3
+
+      - name: Restore tool cache
+        id: tool-cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ github.workspace }}/.tmp
+          key: ${{ runner.os }}-tool-${{ hashFiles('Makefile') }}
+
+      - name: Restore go cache
+        id: go-cache
+        uses: actions/cache@v3
+        with:
+          path: ~/go/pkg/mod
+          key:  ${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ env.GO_CACHE_KEY }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+             ${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ env.GO_CACHE_KEY }}-
+
+      - name: (cache-miss) Bootstrap all project dependencies
+        if: steps.tool-cache.outputs.cache-hit != 'true' || steps.go-cache.outputs.cache-hit != 'true'
+        run: make bootstrap
+
+      - name: Run static analysis
+        run: make static-analysis
+
+  Unit-Test:
+    name: "Unit tests"
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - uses: actions/checkout@v3
+
+      - name: Restore tool cache
+        id: tool-cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ github.workspace }}/.tmp
+          key: ${{ runner.os }}-tool-${{ hashFiles('Makefile') }}
+
+      - name: Restore go cache
+        id: go-cache
+        uses: actions/cache@v3
+        with:
+          path: ~/go/pkg/mod
+          key:  ${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ env.GO_CACHE_KEY }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+             ${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ env.GO_CACHE_KEY }}-
+
+      - name: (cache-miss) Bootstrap all project dependencies
+        if: steps.tool-cache.outputs.cache-hit != 'true' || steps.go-cache.outputs.cache-hit != 'true'
+        run: make bootstrap
+
+      - name: Run unit tests
+        run: make unit

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,79 @@
+issues:
+  max-same-issues: 25
+
+  # TODO: enable this when we have coverage on docstring comments
+#  # The list of ids of default excludes to include or disable.
+#  include:
+#    - EXC0002 # disable excluding of issues about comments from golint
+
+
+linters:
+  # inverted configuration with `enable-all` and `disable` is not scalable during updates of golangci-lint
+  disable-all: true
+  enable:
+    - asciicheck
+    - bodyclose
+    - depguard
+    - dupl
+    - errcheck
+    - errorlint
+    - exportloopref
+    - forcetypeassert
+    - funlen
+    - gocognit
+    - goconst
+    - gocritic
+    - gocyclo
+    - gofmt
+    - tparallel
+    - importas
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - misspell
+    - nolintlint
+    - revive
+    - staticcheck
+    - stylecheck
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - whitespace
+linters-settings:
+  funlen:
+    # Checks the number of lines in a function.
+    # If lower than 0, disable the check.
+    # Default: 60
+    lines: 70
+    # Checks the number of statements in a function.
+    # If lower than 0, disable the check.
+    # Default: 40
+    statements: 50
+output:
+  uniq-by-line: false
+run:
+  timeout: 10m
+
+# do not enable...
+#    - dogsled           # found to be to niche and ineffective
+#    - goprintffuncname  # does not catch all cases and there are exceptions
+#    - nakedret          # does not catch all cases and should not fail a build
+#    - gochecknoglobals
+#    - gochecknoinits    # this is too aggressive
+#    - rowserrcheck disabled per generics https://github.com/golangci/golangci-lint/issues/2649
+#    - godot
+#    - godox
+#    - goerr113
+#    - goimports   # we're using gosimports now instead to account for extra whitespaces (see https://github.com/golang/go/issues/20818)
+#    - golint      # deprecated
+#    - gomnd       # this is too aggressive
+#    - interfacer  # this is a good idea, but is no longer supported and is prone to false positives
+#    - lll         # without a way to specify per-line exception cases, this is not usable
+#    - maligned    # this is an excellent linter, but tricky to optimize and we are not sensitive to memory layout optimizations
+#    - nestif
+#    - prealloc    # following this rule isn't consistently a good idea, as it sometimes forces unnecessary allocations that result in less idiomatic code
+#    - scopelint   # deprecated
+#    - testpackage
+#    - wsl         # this doens't have an auto-fixer yet and is pretty noisy (https://github.com/bombsimon/wsl/issues/90)

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,0 +1,12 @@
+# Developing
+
+## Getting started
+
+In order to test and develop in this repo you will need the following dependencies installed:
+- make
+
+After cloning the repo run `make bootstrap` to download go mod dependencies, create the `/.tmp` dir, and download helper utilities.
+
+The main `make` tasks for common static analysis and testing are `lint`, `lint-fix`, and `unit`.
+
+See `make help` for all the current make tasks.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,113 @@
+TEMP_DIR := ./.tmp
+
+# Command templates #################################
+LINT_CMD := $(TEMP_DIR)/golangci-lint run --tests=false
+GOIMPORTS_CMD := $(TEMP_DIR)/gosimports -local github.com/anchore
+
+# Tool versions #################################
+GOLANGCILINT_VERSION := v1.50.1
+GOSIMPORTS_VERSION := v0.3.5
+BOUNCER_VERSION := v0.4.0
+
+# Formatting variables #################################
+BOLD := $(shell tput -T linux bold)
+PURPLE := $(shell tput -T linux setaf 5)
+GREEN := $(shell tput -T linux setaf 2)
+CYAN := $(shell tput -T linux setaf 6)
+RED := $(shell tput -T linux setaf 1)
+RESET := $(shell tput -T linux sgr0)
+TITLE := $(BOLD)$(PURPLE)
+SUCCESS := $(BOLD)$(GREEN)
+
+define title
+    @printf '$(TITLE)$(1)$(RESET)\n'
+endef
+
+define safe_rm_rf
+	bash -c 'test -z "$(1)" && false || rm -rf $(1)'
+endef
+
+define safe_rm_rf_children
+	bash -c 'test -z "$(1)" && false || rm -rf $(1)/*'
+endef
+
+.DEFAULT_GOAL:=all
+
+
+.PHONY: all
+all: static-analysis test  ## Run all validations
+	@printf '$(SUCCESS)All checks pass!$(RESET)\n'
+
+.PHONY: static-analysis
+static-analysis: check-go-mod-tidy lint check-licenses  ## Run all static analysis checks
+
+.PHONY: test
+test: unit  ## Run all tests (currently unit)
+
+
+## Bootstrapping targets #################################
+
+.PHONY: bootstrap
+bootstrap: $(TEMP_DIR) bootstrap-go bootstrap-tools ## Download and install all tooling dependencies (+ prep tooling in the ./tmp dir)
+	$(call title,Bootstrapping dependencies)
+
+.PHONY: bootstrap-tools
+bootstrap-tools: $(TEMP_DIR)
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(TEMP_DIR)/ $(GOLANGCILINT_VERSION)
+	curl -sSfL https://raw.githubusercontent.com/wagoodman/go-bouncer/master/bouncer.sh | sh -s -- -b $(TEMP_DIR)/ $(BOUNCER_VERSION)
+	# the only difference between goimports and gosimports is that gosimports removes extra whitespace between import blocks (see https://github.com/golang/go/issues/20818)
+	GOBIN="$(realpath $(TEMP_DIR))" go install github.com/rinchsan/gosimports/cmd/gosimports@$(GOSIMPORTS_VERSION)
+
+.PHONY: bootstrap-go
+bootstrap-go:
+	go mod download
+
+$(TEMP_DIR):
+	mkdir -p $(TEMP_DIR)
+
+
+## Static analysis targets #################################
+
+.PHONY: lint
+lint:  ## Run gofmt + golangci lint checks
+	$(call title,Running linters)
+	# ensure there are no go fmt differences
+	@printf "files with gofmt issues: [$(shell gofmt -l -s .)]\n"
+	@test -z "$(shell gofmt -l -s .)"
+
+	# run all golangci-lint rules
+	$(LINT_CMD)
+	@[ -z "$(shell $(GOIMPORTS_CMD) -d .)" ] || (echo "goimports needs to be fixed" && false)
+
+	# go tooling does not play well with certain filename characters, ensure the common cases don't result in future "go get" failures
+	$(eval MALFORMED_FILENAMES := $(shell find . | grep -e ':'))
+	@bash -c "[[ '$(MALFORMED_FILENAMES)' == '' ]] || (printf '\nfound unsupported filename characters:\n$(MALFORMED_FILENAMES)\n\n' && false)"
+
+.PHONY: lint-fix
+lint-fix:  ## Auto-format all source code + run golangci lint fixers
+	$(call title,Running lint fixers)
+	gofmt -w -s .
+	$(GOIMPORTS_CMD) -w .
+	$(LINT_CMD) --fix
+	go mod tidy
+
+.PHONY: check-licenses
+check-licenses:  ## Ensure transitive dependencies are compliant with the current license policy
+	$(call title,Checking for license compliance)
+	$(TEMP_DIR)/bouncer check ./...
+
+check-go-mod-tidy:
+	@ .github/scripts/go-mod-tidy-check.sh && echo "go.mod and go.sum are tidy!"
+
+## Testing targets #################################
+
+.PHONY: unit
+unit: $(TEMP_DIR)  ## Run unit tests
+	$(call title,Running unit tests)
+	go test ./...
+
+## Halp! #################################
+
+.PHONY: help
+help:  ## Display this help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "$(BOLD)$(CYAN)%-25s$(RESET)%s\n", $$1, $$2}'

--- a/adapter/discard/logger.go
+++ b/adapter/discard/logger.go
@@ -1,8 +1,9 @@
 package discard
 
 import (
-	iface "github.com/anchore/go-logger"
 	"io"
+
+	iface "github.com/anchore/go-logger"
 )
 
 var _ iface.Logger = (*logger)(nil)

--- a/adapter/logrus/formatter_test.go
+++ b/adapter/logrus/formatter_test.go
@@ -1,0 +1,37 @@
+package logrus
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_extractPrefix(t *testing.T) {
+
+	tests := []struct {
+		name   string
+		msg    string
+		prefix string
+		rest   string
+	}{
+		{
+			name:   "no prefix",
+			msg:    "hello world",
+			prefix: "",
+			rest:   "hello world",
+		},
+		{
+			name:   "prefix",
+			msg:    "[0000] hello world",
+			prefix: "0000",
+			rest:   "hello world",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prefix, rest := extractPrefix(tt.msg)
+			assert.Equal(t, tt.prefix, prefix)
+			assert.Equal(t, tt.rest, rest)
+		})
+	}
+}

--- a/adapter/logrus/logger.go
+++ b/adapter/logrus/logger.go
@@ -7,8 +7,9 @@ import (
 	"io/ioutil"
 	"os"
 
-	iface "github.com/anchore/go-logger"
 	"github.com/sirupsen/logrus"
+
+	iface "github.com/anchore/go-logger"
 )
 
 var _ iface.Logger = (*logger)(nil)

--- a/adapter/logrus/nested_logger.go
+++ b/adapter/logrus/nested_logger.go
@@ -1,8 +1,9 @@
 package logrus
 
 import (
-	iface "github.com/anchore/go-logger"
 	"github.com/sirupsen/logrus"
+
+	iface "github.com/anchore/go-logger"
 )
 
 var _ iface.Logger = (*nestedLogger)(nil)

--- a/adapter/redact/logger.go
+++ b/adapter/redact/logger.go
@@ -1,0 +1,121 @@
+package redact
+
+import (
+	"fmt"
+	"strings"
+
+	iface "github.com/anchore/go-logger"
+)
+
+var _ iface.Logger = (*redactingLogger)(nil)
+
+type redactingLogger struct {
+	log        iface.MessageLogger
+	redactions StoreReader
+}
+
+func New(log iface.MessageLogger, reader StoreReader) iface.Logger {
+	if r, ok := log.(*redactingLogger); ok {
+		// this is already a redacting logger, so just return it, but attach it to all discovered existing stores
+		r.redactions = newStoreReaderCollection(r.redactions, reader)
+		return r
+	}
+	return &redactingLogger{
+		log:        log,
+		redactions: reader,
+	}
+}
+
+func (r *redactingLogger) Errorf(format string, args ...interface{}) {
+	r.log.Errorf(r.redactString(format), r.redactFields(args)...)
+}
+
+func (r *redactingLogger) Error(args ...interface{}) {
+	r.log.Error(r.redactFields(args)...)
+}
+
+func (r *redactingLogger) Warnf(format string, args ...interface{}) {
+	r.log.Warnf(r.redactString(format), r.redactFields(args)...)
+}
+
+func (r *redactingLogger) Warn(args ...interface{}) {
+	r.log.Warn(r.redactFields(args)...)
+}
+
+func (r *redactingLogger) Infof(format string, args ...interface{}) {
+	r.log.Infof(r.redactString(format), r.redactFields(args)...)
+}
+
+func (r *redactingLogger) Info(args ...interface{}) {
+	r.log.Info(r.redactFields(args)...)
+}
+
+func (r *redactingLogger) Debugf(format string, args ...interface{}) {
+	r.log.Debugf(r.redactString(format), r.redactFields(args)...)
+}
+
+func (r *redactingLogger) Debug(args ...interface{}) {
+	r.log.Debug(r.redactFields(args)...)
+}
+
+func (r *redactingLogger) Tracef(format string, args ...interface{}) {
+	r.log.Tracef(r.redactString(format), r.redactFields(args)...)
+}
+
+func (r *redactingLogger) Trace(args ...interface{}) {
+	r.log.Trace(r.redactFields(args)...)
+}
+
+func (r *redactingLogger) WithFields(fields ...interface{}) iface.MessageLogger {
+	if l, ok := r.log.(iface.FieldLogger); ok {
+		return New(l.WithFields(r.redactFields(fields)...), r.redactions)
+	}
+	return r
+}
+
+func (r *redactingLogger) Nested(fields ...interface{}) iface.Logger {
+	if l, ok := r.log.(iface.NestedLogger); ok {
+		return New(l.Nested(r.redactFields(fields)...), r.redactions)
+	}
+	return r
+}
+
+func (r *redactingLogger) redactFields(fields []interface{}) []interface{} {
+	for i, v := range fields {
+		switch vv := v.(type) {
+		case string:
+			fields[i] = r.redactString(vv)
+		case int, int32, int64, int16, int8, float32, float64:
+			// don't coerce non-string primitives to different types
+			fields[i] = vv
+		case iface.Fields:
+			for kkk, vvv := range vv {
+				delete(vv, kkk) // this key may have data that should be redacted
+				redactedKey := r.redactString(kkk)
+
+				switch vvvv := vvv.(type) {
+				case string:
+					vv[redactedKey] = r.redactString(vvvv)
+				case int, int32, int64, int16, int8, float32, float64:
+					// don't coerce non-string primitives to different types (but still redact the key)
+					vv[redactedKey] = vvvv
+				default:
+					vv[redactedKey] = r.redactString(fmt.Sprintf("%+v", vvvv))
+				}
+			}
+			fields[i] = vv
+		default:
+			// coerce to a string and redact
+			fields[i] = r.redactString(fmt.Sprintf("%+v", vv))
+		}
+	}
+	return fields
+}
+
+func (r *redactingLogger) redactString(str string) string {
+	for _, s := range r.redactions.Values() {
+		// note: we don't use the length of the redaction string to determine the replacement string, as even the length could be considered sensitive
+		str = strings.ReplaceAll(str, s, strings.Repeat("*", 7))
+	}
+	return str
+}

--- a/adapter/redact/logger_test.go
+++ b/adapter/redact/logger_test.go
@@ -1,0 +1,102 @@
+package redact
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anchore/go-logger"
+	"github.com/anchore/go-logger/adapter/logrus"
+)
+
+func Test_RedactingLogger(t *testing.T) {
+	tests := []struct {
+		name   string
+		redact []string
+	}{
+		{
+			name:   "single value",
+			redact: []string{"joe"},
+		},
+		{
+			name:   "multi value",
+			redact: []string{"bob", "alice"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			out, err := logrus.New(logrus.Config{
+				Level: logger.TraceLevel,
+			})
+			require.NoError(t, err)
+
+			buff := bytes.Buffer{}
+			out.(logger.Controller).SetOutput(&buff)
+
+			redactor := New(out, NewStore(test.redact...))
+
+			var fieldObj = make(logger.Fields)
+			for _, v := range test.redact {
+				fieldObj[v] = v
+			}
+
+			format := ""
+			var fields []interface{}
+			for _, v := range test.redact {
+				fields = append(fields, v)
+				format += "%s"
+			}
+
+			fields = append(fields, 3)
+			format += "%d"
+
+			fields = append(fields, int32(3))
+			format += "%d"
+
+			fields = append(fields, 3.2)
+			format += "%f"
+
+			fields = append(fields, float32(4.3))
+			format += "%f"
+
+			fields = append(fields, fieldObj)
+			format += "%+v"
+
+			var interlacedFields []interface{}
+			for i, f := range fields {
+				interlacedFields = append(interlacedFields, fmt.Sprintf("%d", i), f)
+			}
+
+			nestedFieldLogger := redactor.Nested(interlacedFields...).WithFields(interlacedFields...)
+
+			nestedFieldLogger.Tracef(format, fields...)
+			nestedFieldLogger.Trace(fields...)
+
+			nestedFieldLogger.Debugf(format, fields...)
+			nestedFieldLogger.Debug(fields...)
+
+			nestedFieldLogger.Infof(format, fields...)
+			nestedFieldLogger.Info(fields...)
+
+			nestedFieldLogger.Warnf(format, fields...)
+			nestedFieldLogger.Warn(fields...)
+
+			nestedFieldLogger.Errorf(format, fields...)
+			nestedFieldLogger.Error(fields...)
+
+			result := buff.String()
+
+			// this is a string indicator that we've coerced an instance to a new type that does not match the format type (e.g. %d)
+			assert.NotContains(t, result, "%")
+
+			assert.NotEmpty(t, result)
+			for _, v := range test.redact {
+				assert.NotContains(t, result, v)
+			}
+		})
+	}
+}

--- a/adapter/redact/store.go
+++ b/adapter/redact/store.go
@@ -1,0 +1,106 @@
+package redact
+
+import (
+	"sync"
+
+	"github.com/google/uuid"
+	"github.com/scylladb/go-set/strset"
+)
+
+var (
+	_ StoreReader = (*storeReaderCollection)(nil)
+	_ Store       = (*store)(nil)
+)
+
+type Store interface {
+	StoreReader
+	StoreWriter
+}
+
+type StoreReader interface {
+	Values() []string
+	identifiable
+}
+
+type StoreWriter interface {
+	Add(value ...string)
+	identifiable
+}
+
+type identifiable interface {
+	id() string
+}
+
+type storeReaderCollection []StoreReader
+
+func (s storeReaderCollection) id() (val string) {
+	for _, r := range s {
+		val += r.id()
+	}
+	return val
+}
+
+func newStoreReaderCollection(readers ...StoreReader) StoreReader {
+	collection := make(storeReaderCollection, 0, len(readers))
+	ids := strset.New()
+	addReader := func(rs ...StoreReader) {
+		for _, r := range rs {
+			if ids.Has(r.id()) {
+				continue
+			}
+			collection = append(collection, r)
+			ids.Add(r.id())
+		}
+	}
+	for _, r := range readers {
+		if rs, ok := r.(storeReaderCollection); ok {
+			addReader(rs...)
+		} else {
+			addReader(r)
+		}
+	}
+	return collection
+}
+
+type store struct {
+	redactions *strset.Set
+	lock       *sync.RWMutex
+	_id        string
+}
+
+func NewStore(values ...string) Store {
+	return &store{
+		redactions: strset.New(values...),
+		lock:       &sync.RWMutex{},
+		_id:        uuid.New().String(),
+	}
+}
+
+func (w *store) id() string {
+	return w._id
+}
+
+func (w *store) Add(values ...string) {
+	w.lock.Lock()
+	defer w.lock.Unlock()
+	for _, value := range values {
+		if len(value) <= 1 {
+			// smallest possible redaction string is larger than 1 character
+			return
+		}
+		w.redactions.Add(value)
+	}
+}
+
+func (w *store) Values() []string {
+	w.lock.RLock()
+	defer w.lock.RUnlock()
+	return w.redactions.List()
+}
+
+func (s storeReaderCollection) Values() (vals []string) {
+	for _, r := range s {
+		vals = append(vals, r.Values()...)
+	}
+	return vals
+}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,9 @@ module github.com/anchore/go-logger
 go 1.17
 
 require (
+	github.com/google/uuid v1.3.0
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d
+	github.com/scylladb/go-set v1.0.2
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.5.1
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,10 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/fatih/set v0.2.1 h1:nn2CaJyknWE/6txyUDGwysr3G5QC6xWB/PtVjPBbeaA=
+github.com/fatih/set v0.2.1/go.mod h1:+RKtMCH+favT2+3YecHGxcc0b4KyVWA1QWWJUs4E0CI=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/mattn/go-colorable v0.1.12 h1:jF+Du6AlPIjs2BiUiQlKOX0rt3SujHxPnksPKZbaA40=
 github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
 github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9Y=
@@ -9,6 +13,8 @@ github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d h1:5PJl274Y63IEHC+7izoQ
 github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/scylladb/go-set v1.0.2 h1:SkvlMCKhP0wyyct6j+0IHJkBkSZL+TDzZ4E7f7BCcRE=
+github.com/scylladb/go-set v1.0.2/go.mod h1:DkpGd78rljTxKAnTDPFqXSGxvETQnJyuSOQwsHycqfs=
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/logger.go
+++ b/logger.go
@@ -46,7 +46,7 @@ type MessageLogger interface {
 	TraceMessageLogger
 }
 
-//type MessageLogger interface {
+// type MessageLogger interface {
 //	Logf(level Level, format string, args ...interface{})
 //	Log(level Level, args ...interface{})
 //}

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,8 +1,9 @@
 package logger
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestLevelFromVerbosity(t *testing.T) {


### PR DESCRIPTION
This ports the redaction logger construct from quill and anchorectl as a common adapter here in go-logger. Also, it's about time to have a CI pipeline for this repo, so that was added too.