### PR TITLE
Ensure redactor implements controller interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ LINT_CMD := $(TEMP_DIR)/golangci-lint run --tests=false
 GOIMPORTS_CMD := $(TEMP_DIR)/gosimports -local github.com/anchore
 
 # Tool versions #################################
-GOLANGCILINT_VERSION := v1.50.1
-GOSIMPORTS_VERSION := v0.3.5
+GOLANGCILINT_VERSION := v1.52.2
+GOSIMPORTS_VERSION := v0.3.8
 BOUNCER_VERSION := v0.4.0
 
 # Formatting variables #################################
@@ -83,13 +83,17 @@ lint:  ## Run gofmt + golangci lint checks
 	$(eval MALFORMED_FILENAMES := $(shell find . | grep -e ':'))
 	@bash -c "[[ '$(MALFORMED_FILENAMES)' == '' ]] || (printf '\nfound unsupported filename characters:\n$(MALFORMED_FILENAMES)\n\n' && false)"
 
-.PHONY: lint-fix
-lint-fix:  ## Auto-format all source code + run golangci lint fixers
-	$(call title,Running lint fixers)
+.PHONY: format
+format: ## Auto-format all source code
+	$(call title,Running formatters)
 	gofmt -w -s .
 	$(GOIMPORTS_CMD) -w .
-	$(LINT_CMD) --fix
 	go mod tidy
+
+.PHONY: lint-fix
+lint-fix: format  ## Auto-format all source code + run golangci lint fixers
+	$(call title,Running lint fixers)
+	$(LINT_CMD) --fix
 
 .PHONY: check-licenses
 check-licenses:  ## Ensure transitive dependencies are compliant with the current license policy

--- a/adapter/discard/logger.go
+++ b/adapter/discard/logger.go
@@ -16,33 +16,33 @@ func New() iface.Logger {
 	return &logger{}
 }
 
-func (l *logger) Tracef(format string, args ...interface{}) {
+func (l *logger) Tracef(_ string, _ ...interface{}) {
 }
 
-func (l *logger) Debugf(format string, args ...interface{}) {}
+func (l *logger) Debugf(_ string, _ ...interface{}) {}
 
-func (l *logger) Infof(format string, args ...interface{}) {}
+func (l *logger) Infof(_ string, _ ...interface{}) {}
 
-func (l *logger) Warnf(format string, args ...interface{}) {}
+func (l *logger) Warnf(_ string, _ ...interface{}) {}
 
-func (l *logger) Errorf(format string, args ...interface{}) {}
+func (l *logger) Errorf(_ string, _ ...interface{}) {}
 
-func (l *logger) Trace(args ...interface{}) {}
+func (l *logger) Trace(_ ...interface{}) {}
 
-func (l *logger) Debug(args ...interface{}) {}
+func (l *logger) Debug(_ ...interface{}) {}
 
-func (l *logger) Info(args ...interface{}) {}
+func (l *logger) Info(_ ...interface{}) {}
 
-func (l *logger) Warn(args ...interface{}) {}
+func (l *logger) Warn(_ ...interface{}) {}
 
-func (l *logger) Error(args ...interface{}) {}
+func (l *logger) Error(_ ...interface{}) {}
 
-func (l *logger) WithFields(fields ...interface{}) iface.MessageLogger {
+func (l *logger) WithFields(_ ...interface{}) iface.MessageLogger {
 	return l
 }
 
-func (l *logger) Nested(fields ...interface{}) iface.Logger { return l }
+func (l *logger) Nested(_ ...interface{}) iface.Logger { return l }
 
-func (l *logger) SetOutput(writer io.Writer) {}
+func (l *logger) SetOutput(_ io.Writer) {}
 
 func (l *logger) GetOutput() io.Writer { return nil }

--- a/adapter/redact/logger.go
+++ b/adapter/redact/logger.go
@@ -2,12 +2,14 @@ package redact
 
 import (
 	"fmt"
+	"io"
 	"strings"
 
 	iface "github.com/anchore/go-logger"
 )
 
 var _ iface.Logger = (*redactingLogger)(nil)
+var _ iface.Controller = (*redactingLogger)(nil)
 
 type redactingLogger struct {
 	log        iface.MessageLogger
@@ -24,6 +26,19 @@ func New(log iface.MessageLogger, reader StoreReader) iface.Logger {
 		log:        log,
 		redactions: reader,
 	}
+}
+
+func (r *redactingLogger) SetOutput(writer io.Writer) {
+	if c, ok := r.log.(iface.Controller); ok {
+		c.SetOutput(writer)
+	}
+}
+
+func (r *redactingLogger) GetOutput() io.Writer {
+	if c, ok := r.log.(iface.Controller); ok {
+		return c.GetOutput()
+	}
+	return nil
 }
 
 func (r *redactingLogger) Errorf(format string, args ...interface{}) {


### PR DESCRIPTION
Ensures that a logger wrapped with a redactor can additionally forward `Controller` capabilities. The one downside with this approach is that if the underlying logger does not implement the `Controller` interface it will still appear to do so via type assertion -- I believe this is unavoidable without a lot more complexity.

Since this repo doesn't get a lot of attention I also updated the linters + linting targets while I was here (thus the discard logger change).