### PR TITLE
chore: refactor redactor interface

### DIFF
--- a/adapter/redact/store.go
+++ b/adapter/redact/store.go
@@ -1,24 +1,20 @@
 package redact
 
 import (
+	"strings"
 	"sync"
 
 	"github.com/google/uuid"
 	"github.com/scylladb/go-set/strset"
 )
 
-var (
-	_ StoreReader = (*storeReaderCollection)(nil)
-	_ Store       = (*store)(nil)
-)
-
 type Store interface {
-	StoreReader
+	Redactor
 	StoreWriter
 }
 
-type StoreReader interface {
-	Values() []string
+type Redactor interface {
+	RedactString(string) string
 	identifiable
 }
 
@@ -31,19 +27,15 @@ type identifiable interface {
 	id() string
 }
 
-type storeReaderCollection []StoreReader
+// redactorCollection holds a list of redactors, applying all of them to Redact* calls
+type redactorCollection []Redactor
 
-func (s storeReaderCollection) id() (val string) {
-	for _, r := range s {
-		val += r.id()
-	}
-	return val
-}
+var _ Redactor = (*redactorCollection)(nil)
 
-func newStoreReaderCollection(readers ...StoreReader) StoreReader {
-	collection := make(storeReaderCollection, 0, len(readers))
+func newRedactorCollection(readers ...Redactor) Redactor {
+	collection := make(redactorCollection, 0, len(readers))
 	ids := strset.New()
-	addReader := func(rs ...StoreReader) {
+	addReader := func(rs ...Redactor) {
 		for _, r := range rs {
 			if ids.Has(r.id()) {
 				continue
@@ -53,7 +45,7 @@ func newStoreReaderCollection(readers ...StoreReader) StoreReader {
 		}
 	}
 	for _, r := range readers {
-		if rs, ok := r.(storeReaderCollection); ok {
+		if rs, ok := r.(redactorCollection); ok {
 			addReader(rs...)
 		} else {
 			addReader(r)
@@ -62,11 +54,28 @@ func newStoreReaderCollection(readers ...StoreReader) StoreReader {
 	return collection
 }
 
+func (c redactorCollection) RedactString(s string) string {
+	for _, r := range c {
+		s = r.RedactString(s)
+	}
+	return s
+}
+
+func (c redactorCollection) id() (val string) {
+	for _, r := range c {
+		val += r.id()
+	}
+	return val
+}
+
+// store maintains a list of redactions, and implements Redactor Redact* methods
 type store struct {
 	redactions *strset.Set
 	lock       *sync.RWMutex
 	_id        string
 }
+
+var _ Store = (*store)(nil)
 
 func NewStore(values ...string) Store {
 	return &store{
@@ -85,22 +94,23 @@ func (w *store) Add(values ...string) {
 	defer w.lock.Unlock()
 	for _, value := range values {
 		if len(value) <= 1 {
-			// smallest possible redaction string is larger than 1 character
-			return
+			// smallest possible redaction string must be larger than 1 character
+			continue
 		}
 		w.redactions.Add(value)
 	}
 }
 
-func (w *store) Values() []string {
+func (w *store) values() []string {
 	w.lock.RLock()
 	defer w.lock.RUnlock()
 	return w.redactions.List()
 }
 
-func (s storeReaderCollection) Values() (vals []string) {
-	for _, r := range s {
-		vals = append(vals, r.Values()...)
+func (w *store) RedactString(str string) string {
+	for _, s := range w.values() {
+		// note: we don't use the length of the redaction string to determine the replacement string, as even the length could be considered sensitive
+		str = strings.ReplaceAll(str, s, strings.Repeat("*", 7))
 	}
-	return vals
+	return str
 }


### PR DESCRIPTION
This PR refactors the redactor store to use an alternate `Redactor` interface, which does not expose the redacted values.