### PR TITLE
Add function to get all logger levels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+go.work
+go.work.sum
+
 /example
 CHANGELOG.md
 /test/results

--- a/logger.go
+++ b/logger.go
@@ -17,6 +17,16 @@ const (
 	TraceLevel    Level = "trace"
 )
 
+func Levels() []Level {
+	return []Level{
+		ErrorLevel,
+		WarnLevel,
+		InfoLevel,
+		DebugLevel,
+		TraceLevel,
+	}
+}
+
 type Logger interface {
 	MessageLogger
 	FieldLogger


### PR DESCRIPTION
We expose all log levels as constants, but not as an ordered collection of all valid positive values. This PR adds such a function.