### PR TITLE
Dont force enable color by default 

### DIFF
--- a/adapter/logrus/logger.go
+++ b/adapter/logrus/logger.go
@@ -44,7 +44,6 @@ func DefaultConfig() Config {
 func DefaultTextFormatter() logrus.Formatter {
 	return &TextFormatter{
 		TimestampFormat: timestampFormat,
-		ForceColors:     true,
 		ForceFormatting: true,
 	}
 }


### PR DESCRIPTION
This is the upstream fix for https://github.com/anchore/syft/issues/1893 by not forcing ANSI colors to be rendered in log output even when there is no TTY present.