### PR TITLE
correct flags for log file

### DIFF
--- a/adapter/logrus/logger.go
+++ b/adapter/logrus/logger.go
@@ -69,7 +69,7 @@ func Use(l *logrus.Logger, cfg Config) (iface.Logger, error) {
 	var output io.Writer
 	switch {
 	case cfg.EnableConsole && cfg.FileLocation != "":
-		logFile, err := os.OpenFile(cfg.FileLocation, os.O_WRONLY|os.O_CREATE, defaultLogFilePermissions)
+		logFile, err := os.OpenFile(cfg.FileLocation, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, defaultLogFilePermissions)
 		if err != nil {
 			return nil, fmt.Errorf("unable to setup log file: %w", err)
 		}
@@ -77,7 +77,7 @@ func Use(l *logrus.Logger, cfg Config) (iface.Logger, error) {
 	case cfg.EnableConsole:
 		output = os.Stderr
 	case cfg.FileLocation != "":
-		logFile, err := os.OpenFile(cfg.FileLocation, os.O_WRONLY|os.O_CREATE, defaultLogFilePermissions)
+		logFile, err := os.OpenFile(cfg.FileLocation, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, defaultLogFilePermissions)
 		if err != nil {
 			return nil, fmt.Errorf("unable to setup log file: %w", err)
 		}


### PR DESCRIPTION
Trying [grype](https://github.com/anchore/grype), I found that it overwrites previous content in log file without truncating. So in some situations, log file can be broken. Feel free to ask me to use other flags like `O_APPEND` or `O_EXCL`.

Reproduction:
```sh
printf 'previous content\n%.0s' {1..10} > my-log.txt
GRYPE_LOG_LEVEL=info GRYPE_LOG_FILE=./my-log.txt go run ./cmd/grype alpine
```
Resulting my-log.txt:
```
[0000]  INFO grype version: [not provided]
[0001]  INFO found 12 vulnerability matches across 15 packages
ious content
previous content
previous content
previous content
```

Merging this, resulting my-log.txt wil be:
```
[0000]  INFO grype version: [not provided]
[0001]  INFO found 12 vulnerability matches across 15 packages
```