### PR TITLE
Pin go-make to release

### DIFF
--- a/.chronicle.yaml
+++ b/.chronicle.yaml
@@ -1,0 +1,5 @@
+# no matter the change, stay v0 for now
+enforce-v0: true
+
+# since github release pages already have titles that are the tag, we don't need to repeat that in the changelog
+title: ""

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,7 +40,7 @@ jobs:
           persist-credentials: true
 
       # setup checkout, go, go-make, binny, and cache go modules
-      - uses: anchore/go-make/.github/actions/setup@1747ccaf5ab9a24fc6beaff2c4665007fe656462 # dev branch!
+      - uses: anchore/go-make/.github/actions/setup@383ef7852b8ae43a30f424896b52479186d2ea4d # v0.1.0
 
       - name: Create release
         env:

--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       # setup checkout, go, go-make, binny, and cache go modules
-      - uses: anchore/go-make/.github/actions/setup@1747ccaf5ab9a24fc6beaff2c4665007fe656462 # dev branch!
+      - uses: anchore/go-make/.github/actions/setup@383ef7852b8ae43a30f424896b52479186d2ea4d # v0.1.0
 
       - name: Run static analysis
         run: make static-analysis
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       # setup checkout, go, go-make, binny, and cache go modules
-      - uses: anchore/go-make/.github/actions/setup@1747ccaf5ab9a24fc6beaff2c4665007fe656462 # dev branch!
+      - uses: anchore/go-make/.github/actions/setup@383ef7852b8ae43a30f424896b52479186d2ea4d # v0.1.0
 
       - name: Run unit tests
         run: make unit

--- a/.make/go.mod
+++ b/.make/go.mod
@@ -2,7 +2,7 @@ module builder
 
 go 1.25.0
 
-require github.com/anchore/go-make v0.0.0-20260407164102-1747ccaf5ab9
+require github.com/anchore/go-make v0.1.0
 
 require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0 // indirect

--- a/.make/go.sum
+++ b/.make/go.sum
@@ -1,5 +1,5 @@
-github.com/anchore/go-make v0.0.0-20260407164102-1747ccaf5ab9 h1:Ox6/R5xMkekXWNR50oapRh6BnDIUrQFA0QsDicxn8tA=
-github.com/anchore/go-make v0.0.0-20260407164102-1747ccaf5ab9/go.mod h1:JafD2Md95wih7aGmA12yVoReZW3mOgIuwHbw5aOcIOQ=
+github.com/anchore/go-make v0.1.0 h1:w/DTKznE1s0u5H1ahAnLaHRbCyNuOn5sJd0UltKWCIA=
+github.com/anchore/go-make v0.1.0/go.mod h1:JafD2Md95wih7aGmA12yVoReZW3mOgIuwHbw5aOcIOQ=
 github.com/bmatcuk/doublestar/v4 v4.10.0 h1:zU9WiOla1YA122oLM6i4EXvGW62DvKZVxIe6TYWexEs=
 github.com/bmatcuk/doublestar/v4 v4.10.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/goccy/go-yaml v1.19.2 h1:PmFC1S6h8ljIz6gMRBopkjP1TVT7xuwrButHID66PoM=


### PR DESCRIPTION
We used a development version for testing, however, now that go-make has an initial release we'll use that.