### PR TITLE
chore(deps): restore Go version to 1.25.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/anchore/go-logger
 
-go 1.26.2
+go 1.25.0
 
 require (
 	github.com/google/uuid v1.6.0


### PR DESCRIPTION
Restores the go directive in go.mod to 1.25.0 (pre-#64). Bumped in #64 (merge beb30ae87c9ea3ff19e2fac9188f55e626972cee).