### PR TITLE
Tighten workflow-level permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,8 @@
 name: "Release"
 
-permissions:
-  contents: read
-  checks: read
+permissions: {}
 
+# there should never be two releases in progress at the same time
 concurrency:
   group: release
   cancel-in-progress: false
@@ -23,6 +22,8 @@ jobs:
       version: ${{ github.event.inputs.version }}
 
   check-gate:
+    permissions:
+      checks: read   # required for getting the status of specific check names
     uses: anchore/workflows/.github/workflows/check-gate.yaml@4f25313f96311410cad4173f74617654a3e46d48 # v0.3.0
     with:
       checks: '["Static analysis", "Unit tests"]'

--- a/.github/workflows/validate-github-actions.yaml
+++ b/.github/workflows/validate-github-actions.yaml
@@ -7,11 +7,10 @@ on:
     branches:
       - main
     paths:
-      - '.github/workflows/**'
-      - '.github/actions/**'
+      - ".github/workflows/**"
+      - ".github/actions/**"
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   zizmor:

--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -6,8 +6,7 @@ on:
       - main
   pull_request:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
 
@@ -15,6 +14,8 @@ jobs:
     # Note: changing this job name requires making the same update in the .github/workflows/release.yaml pipeline
     name: "Static analysis"
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       # setup checkout, go, go-make, binny, and cache go modules
       - uses: anchore/go-make/.github/actions/setup@383ef7852b8ae43a30f424896b52479186d2ea4d # v0.1.0
@@ -26,6 +27,8 @@ jobs:
     # Note: changing this job name requires making the same update in the .github/workflows/release.yaml pipeline
     name: "Unit tests"
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       # setup checkout, go, go-make, binny, and cache go modules
       - uses: anchore/go-make/.github/actions/setup@383ef7852b8ae43a30f424896b52479186d2ea4d # v0.1.0


### PR DESCRIPTION
Moves the top-level `permissions:` block in each workflow to `{}` and pushes the actual required permissions down to the individual jobs that need them.

Changes:
- `release.yaml`: top-level permissions set to `{}`; `checks: read` added to `check-gate` job (was inherited from workflow level)
- `validate-github-actions.yaml`: top-level permissions set to `{}`; `zizmor` job already had job-level permissions
- `validations.yaml`: top-level permissions set to `{}`; `contents: read` pushed to both `Static-Analysis` and `Unit-Test` jobs

Notes:
- no behavioral changes; the effective permissions for each job are unchanged